### PR TITLE
feat: Add Chroma v2 API support with backward compatibility

### DIFF
--- a/src/clojure_chroma_client/config.clj
+++ b/src/clojure_chroma_client/config.clj
@@ -9,15 +9,16 @@
   ([var default]
    (or (when-let [val (System/getenv var)]
          (when-not (empty? val) val))
-     default)))
+       default)))
 
 (def ^:dynamic *protocol* (getenv "CHROMA_PROTOCOL" "http"))
 (def ^:dynamic *host* (getenv "CHROMA_HOST"))
 (def ^:dynamic *port* (getenv "CHROMA_PORT" 8000))
+(def ^:dynamic *api-version* (getenv "CHROMA_API_VERSION" "v2"))
 (def ^:dynamic *api-key* (getenv "CHROMA_API_KEY"))
 (def ^:dynamic *timeout* (getenv "CHROMA_TIMEOUT" 10000))
-(def ^:dynamic *tenant* (getenv "CHROMA_TENANT"  "default_tenant"))
-(def ^:dynamic *database* (getenv "CHROMA_DATABASE"  "default_database"))
+(def ^:dynamic *tenant* (getenv "CHROMA_TENANT" "default_tenant"))
+(def ^:dynamic *database* (getenv "CHROMA_DATABASE" "default_database"))
 (def ^:dynamic *allow-reset* (truth-str? (getenv "CHROMA_ALLOW_RESET")))
 
 (defn configure
@@ -27,17 +28,19 @@
 
   Configurable options are:
 
-  - `protocol`: http/https. Default https.
+  - `protocol`: http/https. Default http.
   - `host`: Chroma host. Required, no default.
   - `port`: HTTP port. Default 8000.
+  - `api-version`: API version, \"v1\" or \"v2\". Default \"v2\".
   - `timeout`: HTTP timeout in milliseconds. Default 10000.
   - `api-key`: Chroma API key. Required for hosted Chroma, no default.
-  - `tenant`: Unique tentant id. Required for hosted Chroma, no default.
+  - `tenant`: Unique tenant id. Default \"default_tenant\".
+  - `database`: Database name. Default \"default_database\".
   - `allow-reset`: Whether it is possible delete all data via the API. Defaults to false."
   [opts]
   (doseq [[key value] opts]
-    (let [var-sym (symbol "clojure-chroma-client.api" (str "*" (name key) "*"))
+    (let [var-sym (symbol "clojure-chroma-client.config" (str "*" (name key) "*"))
           var (find-var var-sym)]
       (when-not var
-        (throw (ex-info (str "Unknown configuration option:" key) {})))
+        (throw (ex-info (str "Unknown configuration option: " key) {:key key})))
       (alter-var-root var (constantly value)))))


### PR DESCRIPTION
## Summary

This PR adds support for the Chroma v2 API while maintaining full backward compatibility with v1.

### Changes

- **New `*api-version*` config var**: Defaults to `"v2"`, can be set to `"v1"` for legacy behavior
- **v2 API URL structure**: Uses path-based tenant/database routing:
  - v2: `/api/v2/tenants/{tenant}/databases/{database}/{path}`
  - v1: `/api/v1/{path}?tenant=X&database=Y` (unchanged)
- **Fixed `configure` function**: Now correctly looks up vars in `clojure-chroma-client.config` namespace instead of `clojure-chroma-client.api`
- **Added Content-Type header**: All requests now include `Content-Type: application/json`
- **Non-empty metadata handling**: v2 requires non-empty metadata; defaults are now always applied
- **Global endpoints**: `heartbeat`, `version`, and `reset` work correctly without tenant/database

### Breaking Changes

None. The library defaults to v2 API, but setting `CHROMA_API_VERSION=v1` or `(configure {:api-version "v1"})` restores the previous behavior.

### Testing

Tested with:
- Chroma 0.6.x (latest Docker image) which deprecates v1 API
- Collection CRUD operations
- Embedding add/query operations
- Semantic search functionality

### Motivation

Chroma's latest versions (0.5+) deprecate the v1 API and return:
```json
{"error":"Unimplemented","message":"The v1 API is deprecated. Please use /v2 apis"}
```

This PR ensures the library works with both current and future versions of Chroma.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)